### PR TITLE
Fixing a call to a non-static function

### DIFF
--- a/inc/reminder.class.php
+++ b/inc/reminder.class.php
@@ -46,7 +46,7 @@ class PluginSatisfactionReminder extends CommonDBTM {
       return [];
    }
 
-   public function deleteItem(Ticket $ticket){
+   public static function deleteItem(Ticket $ticket){
       $reminder = new Self;
       if($reminder->getFromDBByCrit(['tickets_id'=>$ticket->fields['id']])){
          $reminder->delete(['id' => $reminder->fields["id"]]);


### PR DESCRIPTION
We saw the following error in the logs : 

> [2020-04-06 08:09:36] glpiphplog.ERROR: Toolbox::userErrorHandlerNormal() in C:\wamp64\www\glpi\inc\toolbox.class.php line 658
  *** PHP Deprecated function(8192): Non-static method PluginSatisfactionReminder::deleteItem() should not be called statically
  Backtrace :
  inc\plugin.class.php:1112                          
  inc\commondbtm.class.php:1701                      Plugin::doHook()
  front\ticket.form.php:110                          CommonDBTM->delete()
  {"user":"2@P555"} 
