### PR TITLE
fix(js): move js load when tab is displayed

### DIFF
--- a/inc/surveyanswer.class.php
+++ b/inc/surveyanswer.class.php
@@ -40,6 +40,8 @@ class PluginSatisfactionSurveyAnswer extends CommonDBChild {
 
       // can exists for template
       if ($item->getType() == 'PluginSatisfactionSurvey') {
+         echo Html::css('public/lib/jquery.rateit.css');
+         Html::requireJs('rateit');
          return __('Preview', 'satisfaction');
       }
 
@@ -268,9 +270,6 @@ class PluginSatisfactionSurveyAnswer extends CommonDBChild {
     * @param int $value
     */
    static function showStarAnswer($question, $value = 0) {
-      echo Html::css('public/lib/jquery.rateit.css');
-      Html::requireJs('rateit');
-
       $questions_id = $question['id'];
       $number       = $question['number'];
 


### PR DESCRIPTION
the rateit library is injected in session after the actual load of the libraries
when footer is displayed

Move session injection when "preview" tab is created (before footer)

thie PR prevent this

Internal ref 21410
Fix approved by client