### PR TITLE
fix csrf problem

### DIFF
--- a/front/surveytranslation.form.php
+++ b/front/surveytranslation.form.php
@@ -1,0 +1,21 @@
+<?php
+
+include('../../../inc/includes.php');
+
+if (!isset($_POST['survey_id']) || !isset($_POST['action'])) {
+    exit();
+}
+
+$redirection = Plugin::getWebDir('satisfaction')."/front/survey.form.php?id=";
+$translation = new PluginSatisfactionSurveyTranslation();
+switch($_POST['action']){
+    case 'NEW':
+       $translation->newSurveyTranslation($_POST);
+       Html::redirect($redirection.$_POST['survey_id']);
+       break;
+
+    case 'EDIT':
+       $translation->editSurveyTranslation($_POST);
+       Html::redirect($redirection.$_POST['survey_id']);
+       break;
+}

--- a/inc/surveytranslation.class.php
+++ b/inc/surveytranslation.class.php
@@ -146,6 +146,7 @@ class PluginSatisfactionSurveyTranslation extends CommonDBChild {
             $params);
          echo "};";
          echo "</script>\n";
+
          echo "<div class='center'>".
             "<a class='submit btn btn-primary' href='javascript:addTranslation".
             $item->getType().$item->getID()."$rand();'>". __('Add a new translation').
@@ -368,7 +369,7 @@ class PluginSatisfactionSurveyTranslation extends CommonDBChild {
    function getFormHeader($translationID, $surveyID){
 
       global $CFG_GLPI;
-      $target = Plugin::getWebDir('satisfaction')."/ajax/surveytranslation.form.php";
+      $target = Plugin::getWebDir('satisfaction')."/front/surveytranslation.form.php";
 
       $result = "<form name='form' method='post' action='$target' enctype='multipart/form-data'>";
       $result.= Html::hidden('survey_id', ['value' =>$surveyID]);
@@ -485,7 +486,7 @@ class PluginSatisfactionSurveyTranslation extends CommonDBChild {
 
       $translationList = PluginSatisfactionSurveyTranslationDAO::getSurveyTranslationByCrit($crit);
       $translation = array_pop($translationList);
-      
+
       return $translation['value'];
    }
 }


### PR DESCRIPTION
GLPI 9.5.7 uses csrf token. Verification of this token fails when editing translations.

(Need to create branches 9.5/bugfixes and 10.0/bugfixes to follow your branching model)

The fix relies on changing the path of some HTTP requests. Instead of ajax/ folder, front/ folder should be used. This allows GLPI to search for the token in the rght place (HTTP headers for the 1st case, POST data in the second case).