### PR TITLE
fix: display input rating

### DIFF
--- a/inc/surveyanswer.class.php
+++ b/inc/surveyanswer.class.php
@@ -312,7 +312,7 @@ class PluginSatisfactionSurveyAnswer extends CommonDBChild {
       }
       echo "</select>";
 
-      echo "<div class='rateit' id='stars_$questions_id'></div>";
+      echo "<div id='stars_$questions_id'></div>";
       echo "<script type='text/javascript'>\n";
       echo "$(function() {";
       echo "$('#stars_$questions_id').rateit({value: " . $value . ",


### PR DESCRIPTION
With the ApprovalByMail plugin, the rating input was displayed incorrectly (rating from 0 to 10)

Before:
![image](https://github.com/pluginsGLPI/satisfaction/assets/8530352/eb732de0-8008-404f-a6d9-c7dad5a941fa)

After:
![image](https://github.com/pluginsGLPI/satisfaction/assets/8530352/11685785-3582-4232-ae4e-290ede315f62)


ref !28258