### PR TITLE
Fix CSS path for jQuery RateIt library

### DIFF
--- a/src/SurveyAnswer.php
+++ b/src/SurveyAnswer.php
@@ -81,7 +81,7 @@ class SurveyAnswer extends CommonDBChild
 
         // can exists for template
         if ($item->getType() == Survey::class) {
-            echo Html::css('public/lib/jquery.rateit.css');
+            echo Html::css('/lib/jquery.rateit.css');
             Html::requireJs('rateit');
             return self::createTabEntry(__('Preview', 'satisfaction'));
         }


### PR DESCRIPTION
When creating note-type questions, the stars from the RateIt library are not loaded in current version of GLPI 11.0.6

<img width="1656" height="115" alt="image" src="https://github.com/user-attachments/assets/44c0f3aa-8755-469f-b538-5f1747e74fa4" />

After the the fix.

<img width="1068" height="120" alt="image" src="https://github.com/user-attachments/assets/dc1de111-e31d-4a83-88f2-228360feea7a" />
