### PR TITLE
Fix default value handling in satisfaction.php

### DIFF
--- a/ajax/satisfaction.php
+++ b/ajax/satisfaction.php
@@ -32,5 +32,5 @@
 if (isset($_POST['action_default_value'])) {
     Dropdown::showNumber('default_value', ['max'   => $_POST['default_value'],
         'min'   => 1,
-        'value' => $_POST['value']]);
+        'value' => ($_POST['value'] == '') ? 1 : (int) $_POST['value']]);
 }


### PR DESCRIPTION
Error on GLPI v11.0.6
When a note is selected the defauklt value is undefined because is taking "" as value and Toolbox::isFloat() error is pop

<img width="1450" height="464" alt="image" src="https://github.com/user-attachments/assets/c3db0b0f-c430-45ff-bdb3-1fdc51c679c5" />

This fix makes 1 as default value.  
